### PR TITLE
Fix obsolete link on readme and error sensitive case filename.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ How to Build
 
 After making modifications to the plugin, you need to ensure that you have not yet broken any existing functionality. The way to do this is by:
 
-Set up your copy of wordpress-unit (already placed in this repository under tests/). By following the instructions here - [Unit Testing WordPress Plugins](http://stackoverflow.com/questions/9138215/unit-testing-wordpress-plugins)
+Set up your copy of wordpress-unit (already placed in this repository under tests/). By following the instructions here - [Unit Testing WordPress Plugins](http://web.archive.org/web/20130814152916/http://stackoverflow.com/questions/9138215/unit-testing-wordpress-plugins)
 
 After you make your changes, run the following command in the repository root:
 

--- a/src/models/iterators/pending_broadcasts.php
+++ b/src/models/iterators/pending_broadcasts.php
@@ -1,5 +1,5 @@
 <?php
-include_once dirname(__FILE__)."/../broadcast.php";
+include_once dirname(__FILE__)."/../Broadcast.php";
 
 class PendingBroadcasts implements Iterator, Countable
 {


### PR DESCRIPTION
This will fix:
- dead link on unit test wordpress tutorial at stackoverflow. now using WebArchive back to year 2013.
- fix error file include once not found in "src/models/iterators/pending_broadcasts.php"